### PR TITLE
chore(#44): align index.html with HTML/CSS style guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>My App</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/1fQ4sGBa3wHnqkBKolZiDLqSD4gSF0Q" crossorigin="anonymous">
-    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My App</title>
+  <link href="//cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/1fQ4sGBa3wHnqkBKolZiDLqSD4gSF0Q" crossorigin="anonymous">
+  <script src="//unpkg.com/htmx.org@2.0.4"></script>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-        <div class="container">
-            <a class="navbar-brand" href="/">My App</a>
-        </div>
-    </nav>
-    <div class="container mt-4">
-        <h1>Welcome to My App</h1>
-        <p>Click count: <span id="counter" hx-get="/counter" hx-trigger="load">0</span></p>
-        <button class="btn btn-primary" hx-post="/counter/increment" hx-target="#counter" hx-swap="innerHTML">
-            Click me!
-        </button>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="/">My App</a>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+  </nav>
+  <div class="container mt-4">
+    <h1>Welcome to My App</h1>
+    <p>Click count: <span id="counter" hx-get="/counter" hx-trigger="load">0</span></p>
+    <button class="btn btn-primary" hx-post="/counter/increment" hx-target="#counter" hx-swap="innerHTML">
+      Click me!
+    </button>
+  </div>
+  <script src="//cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Update index.html to comply with the CONTRIBUTING.md guidelines introduced in PR #43:
- Convert all indentation from 4 spaces to 2 spaces
- Change CDN URLs from https:// to protocol-relative // for
  Bootstrap CSS, Bootstrap JS, and htmx.org script references

Note: Go tests could not run in sandbox (go.mod requires go 1.25.0, sandbox has go 1.24.13). Change is HTML-only with no Go code impact. Manual verification is recommended.

---

Closes #44

### Post-script verification

- [x] Branch is not main/master (`agent/44-align-html-style`)
- [x] Secret scan passed (gitleaks — `632a684cf7fe5f943035ba5dba66650bb6ccd7dc..HEAD`)
- [x] Pre-commit hooks passed (authoritative run on runner)
- [x] Tests ran inside sandbox